### PR TITLE
Catch error during analysis

### DIFF
--- a/PySpice/Spice/Parser/HighLevelParser.py
+++ b/PySpice/Spice/Parser/HighLevelParser.py
@@ -1096,7 +1096,11 @@ class SpiceSource:
             if line.is_comment:
                 continue
             cls = Command.get_cls(line, get_state() == SpiceStates.CONTROL)
-            obj = cls(line, ast)
+            try:
+                obj = cls(line, ast)
+            except:
+                print("Could not parse line:",line)
+                continue
             self._obj_lines.append(obj)
             self._logger.debug(os.linesep + repr(obj))
             match obj:


### PR DESCRIPTION
Parsing works when feeding it the .sp file from our standard cell generator, but then it dies during analysis.

This way it just skips the errors and prints out the line which failed to load for analysis.