### PR TITLE
Fix measurement parsing bug

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -1204,7 +1204,7 @@ class NgSpiceShared:
         if meas_start_index and meas_end_index:
             for line in results[meas_start_index:meas_end_index]:
                 # Extract each measurement result as a k,v pair
-                [k, _, v, *_] = line.split()
+                [k, v, *_] = line.replace('=', ' ').split()
                 measurements[k] = float(v)
         return measurements
 


### PR DESCRIPTION
If a measurement result was formatted like "k=v", the previous code would fail to split the result into a key-value pair. This fixes the measurement parsing in these cases by replacing the = with a space prior to splitting.